### PR TITLE
fixed: Removing code bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,14 +19,6 @@ for link in multi_names:
     song_count += 1
     print("checked song #" + str(song_count))
 
-option_2 = input("""
-Remove the trailing code(s) on the file name?
-"yes" or "no" 
->""").lower()
-if option_2 == "no":
-    pass
-
-elif option_2 == "yes":
     testing = testing.decode('utf-8', errors="backslashreplace").split('\n')
     file_name = []
     for result in testing:
@@ -40,7 +32,5 @@ elif option_2 == "yes":
     new_name = new_name + ".mp3"
 
     os.system(f"""rename "{file_name}" "{new_name}" """)
-    print(f""" Old file name:"{file_name}", New file name: "{new_name}" """)
+    print(f"""Old file name:"{file_name}", New file name: "{new_name}" """)
 
-else:
-    raise ValueError("Incorrect input")

--- a/main.py
+++ b/main.py
@@ -31,10 +31,10 @@ elif option_2 == "yes":
     file_name = []
     for result in testing:
         if "Destination" in result:
-            file_name.append(result.split(":")[1][1:-1])
+            file_name.append(result.split(":")[1][1:-4])
 
     file_name = file_name[0]
-    file_name = file_name.replace("web", "mp3")
+    file_name = file_name + "mp3"
 
     new_name = file_name[0:-16]
     new_name = new_name + ".mp3"


### PR DESCRIPTION
Fixed bug where it will only remove the trailing code from the latest downloaded song, not the previous ones. 

The bug was cleared by making the program remove the trailing code from the file name automatically right after a song download. Subsequently, the user lost the ability to choose whether to keep the trailing code or not. 

